### PR TITLE
Remove type from soundTrigger parameter

### DIFF
--- a/Winwheel.js
+++ b/Winwheel.js
@@ -2126,7 +2126,7 @@ function Animation(options)
         'callbackBefore'    : null,            // Function to callback before the wheel is drawn each animation loop.
         'callbackAfter'     : null,            // Function to callback after the wheel is drawn each animation loop.
         'callbackSound'     : null,            // Function to callback if a sound should be triggered on change of segment or pin.
-        'soundTriggerType'  : 'segment'        // Sound trigger type. Default is segment which triggers when segment changes, can be pin if to trigger when pin passes the pointer.
+        'soundTrigger'  : 'segment'        // Sound trigger type. Default is segment which triggers when segment changes, can be pin if to trigger when pin passes the pointer.
     };
 
     // Now loop through the default options and create properties of this class set to the value for
@@ -2348,7 +2348,7 @@ function winwheelTriggerSound()
     var currentTriggerNumber = 0;
 
     // Now figure out if the sound callback should be called depending on the sound trigger type.
-    if (winwheelToDrawDuringAnimation.animation.soundTriggerType == 'pin')
+    if (winwheelToDrawDuringAnimation.animation.soundTrigger == 'pin')
     {
         // So for the pin type we need to work out which pin we are between.
         currentTriggerNumber = winwheelToDrawDuringAnimation.getCurrentPinNumber();

--- a/Winwheel.js
+++ b/Winwheel.js
@@ -2126,7 +2126,7 @@ function Animation(options)
         'callbackBefore'    : null,            // Function to callback before the wheel is drawn each animation loop.
         'callbackAfter'     : null,            // Function to callback after the wheel is drawn each animation loop.
         'callbackSound'     : null,            // Function to callback if a sound should be triggered on change of segment or pin.
-        'soundTrigger'  : 'segment'        // Sound trigger type. Default is segment which triggers when segment changes, can be pin if to trigger when pin passes the pointer.
+        'soundTrigger'      : 'segment'        // Sound trigger type. Default is segment which triggers when segment changes, can be pin if to trigger when pin passes the pointer.
     };
 
     // Now loop through the default options and create properties of this class set to the value for

--- a/examples/pins_and_sound_wheel/index.html
+++ b/examples/pins_and_sound_wheel/index.html
@@ -100,8 +100,8 @@
                     'duration' : 15,
                     'spins'    : 8,
                     'callbackFinished' : alertPrize,
-                    'callbackSound'    : playSound,         // Function to call when the tick sound is to be triggered.
-                    'soundTriggerType' : 'pin'             // Specify pins are to trigger the sound, the other option is 'segment'.
+                    'callbackSound'    : playSound,   // Function to call when the tick sound is to be triggered.
+                    'soundTrigger'     : 'pin'        // Specify pins are to trigger the sound, the other option is 'segment'.
                 },
                 'pins' :
                 {


### PR DESCRIPTION
Removed the "type" from the soundTrigger parameter as decided it was
unnecessary, made the parameter in the examples longer than needed.