### PR TITLE
Add Image Width/Height in 'drawImage'

### DIFF
--- a/Winwheel.js
+++ b/Winwheel.js
@@ -520,7 +520,7 @@ Winwheel.prototype.drawWheelImage = function()
         this.ctx.rotate(this.degToRad(this.rotationAngle));
         this.ctx.translate(-this.centerX, -this.centerY);
 
-        this.ctx.drawImage(this.wheelImage, imageLeft, imageTop);
+        this.ctx.drawImage(this.wheelImage, imageLeft, imageTop, this.wheelImage.width, this.wheelImage.height);
 
         this.ctx.restore();
     }


### PR DESCRIPTION
This is needed when the image has different dimension than the wheel radius dictates.

For example, I have `'outerRadius': 100,`, which means that the wheel has dimensions `200x200`, but I have an image with dimensions `600x600` (I want to keep it like this due to mobile rendering in higher resolution).

So, I do this, and this works:
```
	// Set the image source, once complete this will trigger the onLoad callback (above).
	loadedImg.src = 'wheelimage.png';
	loadedImg.width = 200;
	loadedImg.height = 200;
```

But, without my proposed change, the image is not positioned in the canvas correctly.

This PR solves this issue, we can now use any image width/height we like (different than what the wheel dimensions are).